### PR TITLE
Add StencilJS SLA heatmap scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+www/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # uptime_sla
-This stencil repo takes output from snowflake and turns it into an uptime sla heatmap.
+
+This StencilJS project displays an uptime SLA heatmap based on data from Snowflake. It uses browser-based authentication and provides a search box to filter results.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the dev server:
+   ```bash
+   npm start
+   ```
+
+## Snowflake Integration
+
+The project contains a placeholder data file (`src/assets/data.json`). Replace the logic in `fetchSlaData` with a call to your Snowflake instance using browser OAuth. The Snowflake query should return service names and uptime percentages.
+
+You may use `snowflake-sdk` with OAuth credentials or expose an API that the frontend fetches from.
+
+## Searchable SLA
+
+Use the search box at the top of the page to filter services by name. The heatmap colors change from green (high uptime) to red (low uptime).
+
+## Query Example
+
+Replace the query in `fetchSlaData` with your actual Snowflake SQL. Example placeholder:
+```sql
+SELECT service_name AS name, uptime_percentage AS uptime
+FROM my_schema.service_uptime_daily
+WHERE date >= CURRENT_DATE - 30
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "uptime-sla",
+  "version": "0.0.1",
+  "description": "Uptime SLA heatmap using Stencil",
+  "scripts": {
+    "build": "stencil build",
+    "start": "stencil build --dev --watch --serve",
+    "test": "stencil test --spec"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "@stencil/core": "^2.22.0",
+    "d3": "^7.8.2",
+    "@types/d3": "^7.4.1",
+    "snowflake-sdk": "^1.7.14"
+  }
+}

--- a/src/assets/data.json
+++ b/src/assets/data.json
@@ -1,0 +1,5 @@
+[
+  {"name": "Service A", "uptime": 99.5},
+  {"name": "Service B", "uptime": 99.9},
+  {"name": "Service C", "uptime": 98.7}
+]

--- a/src/components/uptime-heatmap/uptime-heatmap.css
+++ b/src/components/uptime-heatmap/uptime-heatmap.css
@@ -1,0 +1,23 @@
+:host {
+  display: block;
+  font-family: Arial, sans-serif;
+}
+
+.heatmap {
+  margin-top: 1rem;
+}
+
+.row {
+  display: flex;
+  margin-bottom: 4px;
+}
+
+.name {
+  width: 120px;
+  font-weight: bold;
+}
+
+.cell {
+  padding: 4px 8px;
+  color: #fff;
+}

--- a/src/components/uptime-heatmap/uptime-heatmap.tsx
+++ b/src/components/uptime-heatmap/uptime-heatmap.tsx
@@ -1,0 +1,54 @@
+import { Component, h, State } from '@stencil/core';
+import { fetchSlaData } from '../../snowflake';
+
+interface SlaEntry {
+  name: string;
+  uptime: number;
+}
+
+@Component({
+  tag: 'uptime-heatmap',
+  styleUrl: 'uptime-heatmap.css',
+  shadow: true,
+})
+export class UptimeHeatmap {
+  @State() data: SlaEntry[] = [];
+  @State() search: string = '';
+
+  async componentWillLoad() {
+    this.data = await fetchSlaData();
+  }
+
+  private onInput(ev: Event) {
+    const val = (ev.target as HTMLInputElement).value;
+    this.search = val;
+  }
+
+  private get filtered() {
+    return this.data.filter(d => !this.search || d.name.toLowerCase().includes(this.search.toLowerCase()));
+  }
+
+  render() {
+    return (
+      <div>
+        <input type="search" onInput={(ev) => this.onInput(ev)} placeholder="Search services" />
+        <div class="heatmap">
+          {this.filtered.map(item => (
+            <div class="row">
+              <span class="name">{item.name}</span>
+              <span class="cell" style={{backgroundColor: getColor(item.uptime)}}>
+                {item.uptime}%
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+}
+
+function getColor(uptime: number) {
+  if (uptime >= 99.9) return '#2ecc71';
+  if (uptime >= 99.0) return '#f1c40f';
+  return '#e74c3c';
+}

--- a/src/global/app.ts
+++ b/src/global/app.ts
@@ -1,0 +1,3 @@
+export default function() {
+  // global app setup if needed
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Uptime SLA</title>
+  <script type="module" src="/build/uptime-sla.esm.js"></script>
+  <script nomodule src="/build/uptime-sla.js"></script>
+</head>
+<body>
+  <uptime-heatmap></uptime-heatmap>
+</body>
+</html>

--- a/src/snowflake.ts
+++ b/src/snowflake.ts
@@ -1,0 +1,9 @@
+// Placeholder for Snowflake browser authentication and query execution.
+// Replace this logic with actual Snowflake OAuth flow.
+
+export async function fetchSlaData() {
+  // TODO: implement browser OAuth and fetch data from Snowflake.
+  // This example loads static data instead.
+  const resp = await fetch('/assets/data.json');
+  return resp.json();
+}

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -1,0 +1,13 @@
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  namespace: 'uptime-sla',
+  globalScript: 'src/global/app.ts',
+  srcDir: 'src',
+  outputTargets: [
+    {
+      type: 'www',
+      serviceWorker: null,
+    },
+  ],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "lib": ["dom", "es2017"],
+    "moduleResolution": "node",
+    "jsx": "react",
+    "jsxFactory": "h",
+    "target": "es2017"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize StencilJS project for Uptime SLA heatmap
- add placeholder Snowflake integration
- add basic heatmap component with search box
- document setup and usage

## Testing
- `git status --short`